### PR TITLE
Add support for .NET Standard and cross-compilation for both frameworks

### DIFF
--- a/src/IntakeQ.ApiClient.csproj
+++ b/src/IntakeQ.ApiClient.csproj
@@ -1,38 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+        <RootNamespace>IntakeQ.ApiClient</RootNamespace>
+        <AssemblyName>IntakeQ.ApiClient</AssemblyName>
+        <Title>IntakeQ Api Client</Title>
+        <Company>IntakeQ</Company>
+        <Product>IntakeQ.ApiClient</Product>
+        <Version>1.0.0</Version>
+    </PropertyGroup>
 
-	<PropertyGroup>
-		<TargetFramework>net48</TargetFramework>
-		<RootNamespace>IntakeQ.ApiClient</RootNamespace>
-		<AssemblyName>IntakeQ.ApiClient</AssemblyName>
-		<Title>IntakeQ Api Client</Title>
-		<Company>IntakeQ</Company>
-		<Product>IntakeQ.ApiClient</Product>
-		<Version>1.0.0</Version>
-	</PropertyGroup>
-	
-  <ItemGroup>
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Threading.Tasks" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+        <Reference Include="mscorlib" />
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Threading.Tasks" />
+        <Reference Include="System.Xml.Linq" />
+        <Reference Include="System.Data.DataSetExtensions" />
+        <Reference Include="Microsoft.CSharp" />
+        <Reference Include="System.Data" />
+        <Reference Include="System.Xml" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-		<PackageReference Include="System.Buffers" Version="4.5.1" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-	</ItemGroup>
-	
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="System.Buffers" Version="4.5.1" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This includes a handful of changes:

- Fix mixed-spacing in ` CSharpApiClient/src/IntakeQ.ApiClient.csproj` (the .NET framework references used spaces, other references uses tabs, all new .NET 5 projects default to spaces now so I made it adhere to that, if you want me to change that let me know and I'll swap [and maybe drop in an editorconfig]).
- Add `netstandard2.0` as framework target
- Put .NET Framework 4.8 references behind a condition so they're not included for .Net Standard builds
- Add missing reference for .NET Standard build

Also I noticed as part of the last commit (da692d2bbec81c231e823a61743c99a8f3ab1472) the .NET Framework version was updated from v4.6.1 to v4.8, I did some test builds for my commit against the target of `net461` which seemed to be fine, so depending on who else is using this out there they may request another target added and that should work fine.

I built and attached this to a .NET 5 console app and made successful pulls of your API, so looks good from my side, let me know if we need to make any changes or do additional testing against old .NET Framework apps.