### PR TITLE
Remove Console.Write calls

### DIFF
--- a/src/ApiClient.cs
+++ b/src/ApiClient.cs
@@ -88,7 +88,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var intake = JsonConvert.DeserializeObject<Intake>(json);
                     return intake;
                 }
@@ -285,7 +284,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.WriteLine(json);
                     var clients = JsonConvert.DeserializeObject<IEnumerable<ClientProfile>>(json);
                     return clients;
                 }
@@ -437,7 +435,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var appointment = JsonConvert.DeserializeObject<Appointment>(json);
                     return appointment;
                 }
@@ -458,7 +455,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var settings = JsonConvert.DeserializeObject<AppointmentSettings>(json);
                     return settings;
                 }
@@ -505,7 +501,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var result = JsonConvert.DeserializeObject<IEnumerable<Invoice>>(json);
                     return result;
                 }
@@ -574,7 +569,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var result = JsonConvert.DeserializeObject<IEnumerable<Models.File>>(json);
                     return result;
                 }
@@ -615,7 +609,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var result = JsonConvert.DeserializeObject<IEnumerable<Folder>>(json);
                     return result;
                 }
@@ -682,7 +675,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var result = JsonConvert.DeserializeObject<IEnumerable<Practitioner>>(json);
                     return result;
                 }
@@ -830,7 +822,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var result = JsonConvert.DeserializeObject<IEnumerable<Assistant>>(json);
                     return result;
                 }
@@ -928,7 +919,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var notes = JsonConvert.DeserializeObject<IEnumerable<TreatmentNoteSummary>>(json);
                     return notes;
                 }
@@ -949,7 +939,6 @@ namespace IntakeQ.ApiClient
                 if (response.IsSuccessStatusCode)
                 {
                     var json = await response.Content.ReadAsStringAsync();
-                    Console.Write(json);
                     var note = JsonConvert.DeserializeObject<TreatmentNote>(json);
                     return note;
                 }


### PR DESCRIPTION
Some calls still have what appear to be debug `Console.Write` statements in it, which dump out JSON responses of data to stdout, some logging setups may capture this and log it (see: docker containers, loggers attached to an application's stdout, stdoutLogEnabled on IIS, etc.) in places causing us to log sensitive data which is undesirable.

If these are needed and we're okay with implementing an `ILogger<>` pattern I can update this PR as needed, otherwise just removing them would probably be ideal.